### PR TITLE
Fixed missing import (#531)

### DIFF
--- a/addons/source-python/packages/source-python/weapons/engines/csgo/csgo.py
+++ b/addons/source-python/packages/source-python/weapons/engines/csgo/csgo.py
@@ -7,6 +7,7 @@
 # =============================================================================
 # Source.Python
 from . import Weapon as _Weapon
+from weapons.manager import weapon_manager
 #   Filters
 from filters.weapons import WeaponClassIter
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Resolve runtime errors in the CSGO weapons engine caused by a missing weapon manager import.